### PR TITLE
Add Oracle Status to PriceFeed Interface

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "slither.solcPath": "",
     "slither.hiddenDetectors": [],
-    "solidity.compileUsingRemoteVersion": "v0.6.11+commit.5ef660b1",
+    "solidity.compileUsingRemoteVersion": "v0.8.10+commit.fc410830",
     "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -149,7 +149,9 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         ContractsCache memory contractsCache = ContractsCache(troveManager, activePool, thusdToken);
         LocalVariables_openTrove memory vars;
 
-        vars.price = priceFeed.fetchPrice();
+        (IPriceFeed.Status priceFeedStatus, uint price) = priceFeed.fetchPrice();
+        vars.price = price;
+        _requirePriceFeedActive(priceFeedStatus);
         bool isRecoveryMode = _checkRecoveryMode(vars.price);
 
         _requireValidMaxFeePercentage(_maxFeePercentage, isRecoveryMode);
@@ -258,7 +260,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         ContractsCache memory contractsCache = ContractsCache(troveManager, activePool, thusdToken);
         LocalVariables_adjustTrove memory vars;
 
-        vars.price = priceFeed.fetchPrice();
+        (, vars.price) = priceFeed.fetchPrice();
         bool isRecoveryMode = _checkRecoveryMode(vars.price);
 
         if (_isDebtIncrease) {
@@ -332,7 +334,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         ITHUSDToken thusdTokenCached = thusdToken;
 
         _requireTroveisActive(troveManagerCached, msg.sender);
-        uint price = priceFeed.fetchPrice();
+        (, uint price) = priceFeed.fetchPrice();
         _requireNotInRecoveryMode(price);
 
         troveManagerCached.applyPendingRewards(msg.sender);
@@ -589,6 +591,10 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
             require(_maxFeePercentage >= BORROWING_FEE_FLOOR && _maxFeePercentage <= DECIMAL_PRECISION,
                 "Max fee percentage must be between 0.5% and 100%");
         }
+    }
+
+    function _requirePriceFeedActive(IPriceFeed.Status status) internal view {
+        require(status == IPriceFeed.Status.active, "BorrowerOps: PriceFeed is inactive");
     }
 
     // --- ICR and TCR getters ---

--- a/packages/contracts/contracts/Interfaces/IPriceFeed.sol
+++ b/packages/contracts/contracts/Interfaces/IPriceFeed.sol
@@ -6,7 +6,13 @@ interface IPriceFeed {
 
     // --- Events ---
     event LastGoodPriceUpdated(uint _lastGoodPrice);
+    
+    enum Status {
+        active,
+        stale,
+        disabled
+    }
    
     // --- Function ---
-    function fetchPrice() external returns (uint);
+    function fetchPrice() external returns (Status, uint);
 }

--- a/packages/contracts/contracts/PriceFeed.sol
+++ b/packages/contracts/contracts/PriceFeed.sol
@@ -29,14 +29,6 @@ contract PriceFeed is Ownable, CheckContract, BaseMath, IPriceFeed {
     address borrowerOperationsAddress;
     address troveManagerAddress;
 
-    enum Status {
-        chainlinkWorking,
-        usingTellorChainlinkUntrusted,
-        bothOraclesUntrusted,
-        usingTellorChainlinkFrozen,
-        usingChainlinkTellorUntrusted
-    }
-
     // The current status of the PricFeed, which determines the conditions for the next price fetch attempt
     Status public status;
 
@@ -67,7 +59,7 @@ contract PriceFeed is Ownable, CheckContract, BaseMath, IPriceFeed {
     * it uses the last good price seen by Liquity.
     *
     */
-    function fetchPrice() external override returns (uint) {
-        return 1;
+    function fetchPrice() external override returns (Status, uint) {
+        return (status, 1);
     }
 }

--- a/packages/contracts/contracts/Proxy/BorrowerWrappersScript.sol
+++ b/packages/contracts/contracts/Proxy/BorrowerWrappersScript.sol
@@ -128,8 +128,8 @@ contract BorrowerWrappersScript is BorrowerOperationsScript, ETHTransferScript, 
 
     }
 
-    function _getNetTHUSDAmount(uint _collateral) internal returns (uint) {
-        uint price = priceFeed.fetchPrice();
+    function _getNetLUSDAmount(uint _collateral) internal returns (uint) {
+        (, uint price) = priceFeed.fetchPrice();
         uint ICR = troveManager.getCurrentICR(address(this), price);
 
         uint THUSDAmount = _collateral.mul(price).div(ICR);

--- a/packages/contracts/contracts/Proxy/BorrowerWrappersScript.sol
+++ b/packages/contracts/contracts/Proxy/BorrowerWrappersScript.sol
@@ -128,7 +128,7 @@ contract BorrowerWrappersScript is BorrowerOperationsScript, ETHTransferScript, 
 
     }
 
-    function _getNetLUSDAmount(uint _collateral) internal returns (uint) {
+    function _getNetTHUSDAmount(uint _collateral) internal returns (uint) {
         (, uint price) = priceFeed.fetchPrice();
         uint ICR = troveManager.getCurrentICR(address(this), price);
 

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -640,7 +640,7 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
     }
 
     function _requireNoUnderCollateralizedTroves() internal {
-        uint price = priceFeed.fetchPrice();
+        (, uint price) = priceFeed.fetchPrice();
         address lowestTrove = sortedTroves.getLast();
         uint ICR = troveManager.getCurrentICR(lowestTrove, price);
         require(ICR >= MCR, "StabilityPool: Cannot withdraw while there are troves with ICR < MCR");

--- a/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
+++ b/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
@@ -19,11 +19,11 @@ contract PriceFeedTestnet is IPriceFeed {
         return _price;
     }
 
-    function fetchPrice() external override returns (uint256) {
+    function fetchPrice() external override returns (Status, uint256) {
         // Fire an event just like the mainnet version would.
         // This lets the subgraph rely on events to get the latest price even when developing locally.
         emit LastGoodPriceUpdated(_price);
-        return _price;
+        return (Status.active, _price);
     }
 
     // Manual external price setter.

--- a/packages/contracts/contracts/TroveManager.sol
+++ b/packages/contracts/contracts/TroveManager.sol
@@ -481,8 +481,8 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
 
         LiquidationTotals memory totals;
 
-        vars.price = priceFeed.fetchPrice();
-        vars.THUSDInStabPool = stabilityPoolCached.getTotalTHUSDDeposits();
+        (, vars.price) = priceFeed.fetchPrice();
+        vars.LUSDInStabPool = stabilityPoolCached.getTotalLUSDDeposits();
         vars.recoveryModeAtStart = _checkRecoveryMode(vars.price);
 
         // Perform the appropriate liquidation sequence - tally the values, and obtain their totals
@@ -623,8 +623,8 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         LocalVariables_OuterLiquidationFunction memory vars;
         LiquidationTotals memory totals;
 
-        vars.price = priceFeed.fetchPrice();
-        vars.THUSDInStabPool = stabilityPoolCached.getTotalTHUSDDeposits();
+        (, vars.price) = priceFeed.fetchPrice();
+        vars.LUSDInStabPool = stabilityPoolCached.getTotalLUSDDeposits();
         vars.recoveryModeAtStart = _checkRecoveryMode(vars.price);
 
         // Perform the appropriate liquidation sequence - tally values and obtain their totals.
@@ -919,7 +919,11 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         RedemptionTotals memory totals;
 
         _requireValidMaxFeePercentage(_maxFeePercentage);
-        totals.price = priceFeed.fetchPrice();
+        _requireAfterBootstrapPeriod();
+        (IPriceFeed.Status priceFeedStatus, uint256 price) = priceFeed.fetchPrice();
+        totals.price = price;
+        // Only allow direct redemption if oracle is stale or disabled
+        _requirePriceFeedInactive(priceFeedStatus);
         _requireTCRoverMCR(totals.price);
         _requireAmountGreaterThanZero(_THUSDamount);
         _requireTHUSDBalanceCoversRedemption(contractsCache.thusdToken, msg.sender, _THUSDamount);
@@ -1468,6 +1472,15 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
     function _requireTCRoverMCR(uint _price) internal view {
         require(_getTCR(_price) >= MCR, "TroveManager: Cannot redeem when TCR < MCR");
     }
+
+    function _requireAfterBootstrapPeriod() internal view {
+        uint systemDeploymentTime = lqtyToken.getDeploymentStartTime();
+        require(block.timestamp >= systemDeploymentTime.add(BOOTSTRAP_PERIOD), "TroveManager: Redemptions are not allowed during bootstrap phase");
+    }
+
+    function _requirePriceFeedInactive(IPriceFeed.Status status) internal view {
+        require(status == IPriceFeed.Status.stale || status == IPriceFeed.Status.disabled, "TroveManager: Redemptions are only allowed if the price feed is stale or disabled");
+    }    
 
     function _requireValidMaxFeePercentage(uint _maxFeePercentage) internal pure {
         require(_maxFeePercentage >= REDEMPTION_FEE_FLOOR && _maxFeePercentage <= DECIMAL_PRECISION,

--- a/packages/contracts/contracts/TroveManager.sol
+++ b/packages/contracts/contracts/TroveManager.sol
@@ -482,7 +482,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         LiquidationTotals memory totals;
 
         (, vars.price) = priceFeed.fetchPrice();
-        vars.LUSDInStabPool = stabilityPoolCached.getTotalLUSDDeposits();
+        vars.THUSDInStabPool = stabilityPoolCached.getTotalTHUSDDeposits();
         vars.recoveryModeAtStart = _checkRecoveryMode(vars.price);
 
         // Perform the appropriate liquidation sequence - tally the values, and obtain their totals
@@ -624,7 +624,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         LiquidationTotals memory totals;
 
         (, vars.price) = priceFeed.fetchPrice();
-        vars.LUSDInStabPool = stabilityPoolCached.getTotalLUSDDeposits();
+        vars.THUSDInStabPool = stabilityPoolCached.getTotalTHUSDDeposits();
         vars.recoveryModeAtStart = _checkRecoveryMode(vars.price);
 
         // Perform the appropriate liquidation sequence - tally values and obtain their totals.

--- a/packages/contracts/contracts/TroveManager.sol
+++ b/packages/contracts/contracts/TroveManager.sol
@@ -919,7 +919,6 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         RedemptionTotals memory totals;
 
         _requireValidMaxFeePercentage(_maxFeePercentage);
-        _requireAfterBootstrapPeriod();
         (IPriceFeed.Status priceFeedStatus, uint256 price) = priceFeed.fetchPrice();
         totals.price = price;
         // Only allow direct redemption if oracle is stale or disabled
@@ -1471,11 +1470,6 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
 
     function _requireTCRoverMCR(uint _price) internal view {
         require(_getTCR(_price) >= MCR, "TroveManager: Cannot redeem when TCR < MCR");
-    }
-
-    function _requireAfterBootstrapPeriod() internal view {
-        uint systemDeploymentTime = lqtyToken.getDeploymentStartTime();
-        require(block.timestamp >= systemDeploymentTime.add(BOOTSTRAP_PERIOD), "TroveManager: Redemptions are not allowed during bootstrap phase");
     }
 
     function _requirePriceFeedInactive(IPriceFeed.Status status) internal view {


### PR DESCRIPTION
Only allow direct redemptions if oracle is `stale` or `disabled`
Only allow new Trove creation if oracle is `active`