### PR TITLE
Change darkGrey theme to dark

### DIFF
--- a/packages/dev-frontend/src/components/ActionDescription.tsx
+++ b/packages/dev-frontend/src/components/ActionDescription.tsx
@@ -29,7 +29,7 @@ export const ActionDescription = ({ title, children }: ActionDescriptionProps): 
     >
       <Flex sx={{ alignItems: "center", fontSize: "0.9em" }}>
         <GenericIcon imgSrc="./icons/rounded-info.svg" 
-            sx={colorMode === "dark" ? {filter: PURPLE_FILTER} : colorMode === "darkGrey" ? {filter: WHITE_FILTER} : {}} height={"18px"} />
+            sx={colorMode === "dark" ? {filter: WHITE_FILTER} : {}} height={"18px"} />
         <Flex sx={{ alignItems: "start", flexDirection: "column", ml: "1.8em", gap: "0.5em" }}>
           <Text sx={{ color: "text" }}>{title}</Text>
           <Text sx={{ color: "greytext" }}>{children}</Text>

--- a/packages/dev-frontend/src/components/Dashboard/Chart/LineChart.tsx
+++ b/packages/dev-frontend/src/components/Dashboard/Chart/LineChart.tsx
@@ -208,13 +208,13 @@ export const LineChart = (): JSX.Element => {
         lineTension: 0.4,
         label: 'TVL',
         data: chartData,
-        borderColor: colorMode === "dark" ? "#7d00ff" : colorMode === "darkGrey" ? "#f3f3f3b8" : "#20cb9d",
-        pointBackgroundColor: colorMode === 'dark' ? "#7d00ff" : colorMode === "darkGrey" ? "#f3f3f3b8" : "#20cb9d",
+        borderColor: colorMode === "dark" ? "#f3f3f3b8" : "#20cb9d",
+        pointBackgroundColor: colorMode === 'dark' ? "#f3f3f3b8" : "#20cb9d",
         backgroundColor: (context: ScriptableContext<"line">) => {
           const ctx = context.chart.ctx;
           const gradient = ctx.createLinearGradient(0, 0, 0, 200);
-          gradient.addColorStop(0, colorMode === "dark" ? "#7c00fd8c" : colorMode === "darkGrey" ? "#e5e5e5b8" : "#28c39b40");
-          gradient.addColorStop(1, colorMode === "dark" ? "#7d00ff00" : colorMode === "darkGrey" ? "#f3f3f321" :  "#ffffff40");
+          gradient.addColorStop(0, colorMode === "dark" ? "#e5e5e5b8" : "#28c39b40");
+          gradient.addColorStop(1, colorMode === "dark" ? "#f3f3f321" :  "#ffffff40");
           return gradient;
         },
       },

--- a/packages/dev-frontend/src/components/Dashboard/Chart/LoadingChart.tsx
+++ b/packages/dev-frontend/src/components/Dashboard/Chart/LoadingChart.tsx
@@ -8,11 +8,11 @@ export const LoadingChart = (): JSX.Element => {
       <svg width='100%' preserveAspectRatio='xMinYMin slice' viewBox='0 0 766 300'>
         <defs>
           <linearGradient id='linear-gradient'>
-            <stop offset='0%' stopColor={colorMode === "dark" ? "#7d00ff" : colorMode === "darkGrey" ? "#e4e5e7b8" :  "#e2e9ef"} />
-            <stop offset='33%' stopColor={colorMode === "dark" ? "#7d00ff" : colorMode === "darkGrey" ? "#e4e5e7b8" :  "#e2e9ef"} />
-            <stop offset='50%' stopColor={colorMode === "dark" ? "#000" : colorMode === "darkGrey" ? "#fff" :  "#aebcc9"} />
-            <stop offset='67%' stopColor={colorMode === "dark" ? "#7d00ff" : colorMode === "darkGrey" ? "#e4e5e7b8" :  "#e2e9ef"} />
-            <stop offset='100%' stopColor={colorMode === "dark" ? "#7d00ff" : colorMode === "darkGrey" ? "#e4e5e7b8" :  "#e2e9ef"} />
+            <stop offset='0%' stopColor={colorMode === "dark" ? "#e4e5e7b8" :  "#e2e9ef"} />
+            <stop offset='33%' stopColor={colorMode === "dark" ? "#e4e5e7b8" :  "#e2e9ef"} />
+            <stop offset='50%' stopColor={colorMode === "dark" ? "#fff" :  "#aebcc9"} />
+            <stop offset='67%' stopColor={colorMode === "dark" ? "#e4e5e7b8" :  "#e2e9ef"} />
+            <stop offset='100%' stopColor={colorMode === "dark" ? "#e4e5e7b8" :  "#e2e9ef"} />
             <animateTransform
               attributeName='gradientTransform'
               type='translate'
@@ -24,8 +24,8 @@ export const LoadingChart = (): JSX.Element => {
             />
           </linearGradient>
           <linearGradient id='area' x1='50%' y1='-104.497044%' x2='50%' y2='85.1203676%'>
-            <stop offset='0%' stopColor={colorMode === "dark" ? "#7d00ff00" : colorMode === "darkGrey" ? "#f3f3f321" :  "#fff"} />
-            <stop offset='100%' stopColor={colorMode === "dark" ? "#7c00fd8c" : colorMode === "darkGrey" ? "#e4e5e7b8" : "#e8eef5"} />
+            <stop offset='0%' stopColor={colorMode === "dark" ? "#f3f3f321" :  "#fff"} />
+            <stop offset='100%' stopColor={colorMode === "dark" ? "#e4e5e7b8" : "#e8eef5"} />
           </linearGradient>
         </defs>
         <g fill='none' fillRule='evenodd' className='graph-example'>

--- a/packages/dev-frontend/src/components/ExternalLinks.tsx
+++ b/packages/dev-frontend/src/components/ExternalLinks.tsx
@@ -18,10 +18,10 @@ export const ExternalLinks = (): JSX.Element => {
         bottom: 0
       }}>
         <Link variant="socialIcons" href="https://discord.gg/mE2u9YuA47" target="_blank">
-          <Image src="./icons/discord.svg" sx={colorMode === "darkGrey" ? {filter: GREY_FILTER} : {filter: DARK_FILTER}} />
+          <Image src="./icons/discord.svg" sx={colorMode === "dark" ? {filter: GREY_FILTER} : {filter: DARK_FILTER}} />
         </Link>
         <Link variant="socialIcons" href="https://github.com/LiquidEnergyDollar" target="_blank">
-          <Image src="./icons/github.svg" sx={colorMode === "darkGrey" ? {filter: GREY_FILTER} : {filter: DARK_FILTER}} />
+          <Image src="./icons/github.svg" sx={colorMode === "dark" ? {filter: GREY_FILTER} : {filter: DARK_FILTER}} />
         </Link>
       </Flex>
     </>

--- a/packages/dev-frontend/src/components/Header.tsx
+++ b/packages/dev-frontend/src/components/Header.tsx
@@ -17,7 +17,7 @@ export const Header = ({ children }: HeaderProps): JSX.Element => {
   return (
     <Container variant="header">
       <Link variant="logo" to="/">
-        <GenericIcon imgSrc={colorMode === "dark" || colorMode === "darkGrey" ? "./favicon.png" : "./favicon.png"} height={logoHeight} />
+        <GenericIcon imgSrc="./favicon.png" height={logoHeight} />
         <Heading as="h1" sx={{ ml: ".5em" }}>
           LED
         </Heading>
@@ -37,12 +37,12 @@ export const Header = ({ children }: HeaderProps): JSX.Element => {
               width: "1.5em"
             }}
             onClick={() => {
-              setColorMode(colorMode === 'default' ? 'darkGrey' : 'default')
+              setColorMode(colorMode === 'default' ? 'dark' : 'default')
             }}
           >
             <GenericIcon 
               justifyContent="center" 
-              imgSrc={colorMode === "darkGrey" ? "./icons/sun.svg" : "./icons/moon.svg"} 
+              imgSrc={colorMode === "dark" ? "./icons/sun.svg" : "./icons/moon.svg"} 
               sx={colorMode === "dark" ? {filter: WHITE_FILTER} : {}} 
             />
           </Flex>

--- a/packages/dev-frontend/src/components/WalletConnector.tsx
+++ b/packages/dev-frontend/src/components/WalletConnector.tsx
@@ -127,7 +127,7 @@ export const WalletConnector = ({ children, loader }: WalletConnectorProps): JSX
           alignItems: "center",
           mb: "2.5rem"
         }}>
-          <GenericIcon imgSrc={colorMode === "dark" || colorMode === "darkGrey" ? "./dark-led-logo.png" : "./light-led-logo.png"} height={"66px"} />
+          <GenericIcon imgSrc={colorMode === "dark" ? "./dark-led-logo.png" : "./light-led-logo.png"} height={"66px"} />
         </Flex>
         <Paragraph sx={{
           fontWeight: "bold",

--- a/packages/dev-frontend/src/theme.ts
+++ b/packages/dev-frontend/src/theme.ts
@@ -200,23 +200,6 @@ const theme: Theme = {
     metaMaskInnerButtonBg: "#CBD5E0",  
     modes: {
       dark: {
-        primary: "#7D00FF",
-        info: baseColors.red,
-        border: "#9974FF23",
-        greytext: "#b1bccc",
-        
-        activeMenu: baseColors.white,
-        menu: "#b1bccc",
-        text: "#FCF9FF",
-        heading: "#9974FF",
-        background: "#200c5a",
-        muted: "#9974FF23",
-        systemStatsBackGround: "#200c5a",
-        wrapperBackground: "#150640",
-        metaMaskButtonBg: "#7D00FF", 
-        metaMaskInnerButtonBg: "#200c5a"
-      },
-      darkGrey: {
         primary: "#4A5568",  
         title: baseColors.white,
         info: baseColors.red,


### PR DESCRIPTION
`theme-ui` uses the user's browser theme as the initial theme for the site.
The values are either `dark`  or `light` so I'm renaming the `darkGrey` theme to use `dark` and getting rid of the old one.